### PR TITLE
Add support for proxy by allowing HttpMessageHandler to be passed.

### DIFF
--- a/src/MessageCards/Webhooks/Webhook.cs
+++ b/src/MessageCards/Webhooks/Webhook.cs
@@ -12,7 +12,7 @@ namespace MessageCards.Webhooks
 
         public Webhook(string url) : this(url, null) { }
 
-        internal Webhook(string url, HttpMessageHandler handler = null, bool disposeHandler = true)
+        public Webhook(string url, HttpMessageHandler handler = null, bool disposeHandler = true)
         {
             if (!Uri.TryCreate(url, UriKind.RelativeOrAbsolute, out Uri uriResult) || (uriResult.Scheme != Uri.UriSchemeHttp && uriResult.Scheme != Uri.UriSchemeHttps))
             {


### PR DESCRIPTION
Wanted to pass proxy configurations, but could find a way. This PR provides that option.

Example:

```
var webHook = new Webhook(teamsWebHookUrl, 
  new HttpClientHandler { Proxy = new WebProxy("proxyurl", 1234)});
var task = webHook.PostAsync(card);
task.Wait();
```
