### PR TITLE
Allow a ThemeColor to be set on the MessageCard

### DIFF
--- a/src/MessageCards/MessageCard.cs
+++ b/src/MessageCards/MessageCard.cs
@@ -29,6 +29,8 @@ namespace MessageCards
         public string Title { get; }
 
         public string Text { get; set; }
+        
+        public string ThemeColor { get; set; }
 
         public string Summary
         {


### PR DESCRIPTION
You can set a ThemeColor for the MessageCard which accents the card with a hex value color, this can be useful to visually indicate the status of the card.

The MessageCard shown in Teams - the first message without a ThemeColor and the second set to a green colour.

e.g.

            MessageCard card2 = new MessageCard("New feedback");
            card2.Summary = "This is the summary";
            card2.ThemeColor = "28FB2F";
            card2.Text = "This is the text";

![image](https://user-images.githubusercontent.com/1718417/94549087-90caa580-0249-11eb-97b8-941c46938f8a.png)
